### PR TITLE
Fixing searching bug on proceedings page

### DIFF
--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -53,12 +53,8 @@ $monospacetype: (
     box-sizing: border-box;
 }
 .collapse {
-  display: block;
-  max-height: 0px;
-  overflow: hidden;
-  /*transition: max-height .5s cubic-bezier(0, 1, 0, 1);*/
+  display: none;
 &.show {
-    max-height: 99em;
-    /*transition: max-height .5s ease-in-out;*/
+    display: block;
   }
 }


### PR DESCRIPTION
Searching the [proceedings page](https://www.nime.org/archives/) with `Ctrl/Cmd+F` (browser's _Find_ feature) brings mostly results where nothing seems to be found (no highlighted text).
![search issue](https://user-images.githubusercontent.com/16505191/99892503-c30ae900-2c75-11eb-92bc-eb9026393ae7.gif)
This makes the search-ability issues of NIME proceedings even worse than discussed in #4. The empty results appear because all abstracts and BibTex are included in the page's DOM even when they are not visible. The code responsible for this behaviour is the following:
https://github.com/NIME-conference/nime-website/blob/a9f742607639767b556e770b4e9e170fb13f0cf0/assets/styles.scss#L55-L64
Making the `max-height` of abstracts and BibTex containers zero hides them but they are still searchable.
Using `display` for hiding fixes the issue.
```scss
.collapse {
  display: none;
&.show {
    display: block;
  }
}
```